### PR TITLE
feat(kafka): implement docker-compose.yml

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 sr-sig3
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
-# news-stream-broker
+# News Stream Broker
+
+This repository contains the Kafka infrastructure setup for the news streaming service.
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+
+## Setup
+
+1. Clone the repository:
+```bash
+git clone [repository-url]
+cd news-stream-broker
+```
+
+2. Start the Kafka infrastructure:
+```bash
+docker-compose up -d
+```
+
+3. Create Kafka topics:
+```bash
+chmod +x scripts/create-topics.sh
+./scripts/create-topics.sh
+```
+
+## Services
+
+- **Kafka**: Running on `localhost:9092`
+- **Zookeeper**: Running on `localhost:2181`
+- **Kafdrop**: Web UI for Kafka monitoring, accessible at `http://localhost:9000`
+
+## Topics
+
+- `news-topic`: Main topic for news data
+- `news-topic-raw`: Raw news data
+- `news-topic-processed`: Processed news data
+
+## Usage
+
+### Connecting to Kafka
+
+Producers and consumers can connect to Kafka using:
+```
+bootstrap.servers=localhost:9092
+```
+
+### Monitoring
+
+Access the Kafdrop UI at `http://localhost:9000` to monitor:
+- Topics
+- Messages
+- Consumer groups
+- Brokers
+
+## Development
+
+### Adding New Topics
+
+1. Edit `scripts/create-topics.sh`
+2. Add the new topic to the `topics` array
+3. Run the script again
+
+### Stopping the Services
+
+```bash
+docker-compose down
+```
+
+## Troubleshooting
+
+1. If services fail to start, check the logs:
+```bash
+docker-compose logs
+```
+
+2. To restart the services:
+```bash
+docker-compose restart
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3'
 services:
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: wurstmeister/zookeeper
     ports:
       - "2181:2181"
     networks:
       - kafka-network
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.8.0
+    image: wurstmeister/kafka
     ports:
       - "9092:9092"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:3.4.6
+    ports:
+      - "2181:2181"
+    networks:
+      - kafka-network
+
+  kafka:
+    image: wurstmeister/kafka:2.13-2.8.0
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+    depends_on:
+      - zookeeper
+    networks:
+      - kafka-network
+
+  kafdrop:
+    image: obsidiandynamics/kafdrop:3.30.0
+    ports:
+      - "9000:9000"
+    environment:
+      KAFKA_BROKERCONNECT: kafka:9092
+      JVM_OPTS: "-Xms32M -Xmx64M"
+    depends_on:
+      - kafka
+    networks:
+      - kafka-network
+
+networks:
+  kafka-network:
+    driver: bridge 

--- a/scripts/create-topics.sh
+++ b/scripts/create-topics.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Kafka broker address
+BROKER="localhost:9092"
+
+# Create topics
+topics=(
+    "news-topic"
+    "news-topic-raw"
+    "news-topic-processed"
+)
+
+for topic in "${topics[@]}"; do
+    echo "Creating topic: $topic"
+    docker-compose exec kafka kafka-topics.sh --create \
+        --bootstrap-server $BROKER \
+        --topic $topic \
+        --partitions 3 \
+        --replication-factor 1
+done
+
+echo "All topics created successfully!" 


### PR DESCRIPTION
Docker compose로 zookeeper, kafka 서비스를 실행하도록 구현

zookeeper가 kafka cluster를 관리하므로 
zookeeper 먼저 실행 후 kafka가 zookeeper에 연결되어 kafka 서비스 실행

## Zookeeper
- Kafka 클러스터의 메타데이터 관리
- 브로커 상태 모니터링
- 토픽 설정 관리
- 컨트롤러(leader) 선출
- 필수 의존성 서비스
## Kafka
- 실제 메시지 브로커
- 메시지 저장 및 전달
- 프로듀서/컨슈머와 통신


### 참고: docker compose 사용하는 이유
1. 환경 일관성
로컬, 개발, 테스트, 스테이징 등 모든 환경에서 동일한 Kafka 버전과 설정 사용.
개발자마다 Kafka 설치 방법 다르거나, 버전 달라서 발생하는 문제 방지.

2. 의존성 관리
Kafka는 Zookeeper에 의존. 
Docker Compose 사용하면 Zookeeper와 Kafka를 한 번에 띄울 수 있어 편리.
추가로 필요한 서비스(예: Schema Registry, Kafdrop 등) 쉽게 추가.

3. 설정 관리
Kafka 설정(예: 브로커 설정, 토픽 설정 등)을 코드로 관리할 수 있어 버전 관리 용이.
환경별로 다른 설정을 적용하기 쉬움.

4. 개발 편의성
docker-compose up 한 줄로 Kafka와 관련 서비스 모두 실행할 수 있음.
개발 중에 Kafka 재시작하거나 설정 변경할 때 편리.

5. 테스트 용이성
CI/CD 파이프라인에서도 동일한 환경으로 테스트 가능.
테스트용 토픽이나 데이터 쉽게 초기화 가능.